### PR TITLE
bugfix webpdecoder.ps1

### DIFF
--- a/webpdecoder.ps1
+++ b/webpdecoder.ps1
@@ -73,9 +73,9 @@ if($FolderBrowser.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK){
             #pngファイルを削除
             Remove-Item $pngFile
         }        
-        echo "$filename.webpを$filename.$fileTypeに変換しました。"
+        Write-Output "${filename}.webpを${filename}.${fileType}に変換しました。"
     }
 }
 else {
-    [System.Windows.MessageBox]::Show('フォルダは選択されませんでした')
+    [System.Windows.Forms.MessageBox]::Show('フォルダは選択されませんでした')
 }


### PR DESCRIPTION
微細ですが、
1) 変数名に {} がないと、日本語が続くとき正しく展開されないので修正。
2) 「.Forms」が抜けていた。

なお、窓がすぐ閉じてしまうとメッセージを出してもあまり意味がないので、末尾で Read-Host を一回待機しても良いような気がしました。